### PR TITLE
Migrate to GradleMavenPush https://github.com/Vorlonsoft/GradleMavenPush

### DIFF
--- a/badges/build.gradle
+++ b/badges/build.gradle
@@ -10,4 +10,4 @@ android {
     }
 }
 
-apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'
+apply from: 'https://raw.github.com/Vorlonsoft/GradleMavenPush/master/maven-push.gradle'

--- a/badges/gradle.properties
+++ b/badges/gradle.properties
@@ -1,3 +1,2 @@
 POM_NAME=Android Badges Library
 POM_ARTIFACT_ID=badges
-POM_PACKAGING=aar

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,11 +4,9 @@ GROUP=com.github.arturogutierrez
 
 POM_DESCRIPTION=Library to show badges in app icons on supported launchers.
 POM_URL=https://github.com/arturogutierrez/Badges
-POM_SCM_URL=https://github.com/arturogutierrez/Badges
 POM_SCM_CONNECTION=scm:git@github.com:arturogutierrez/Badges.git
-POM_SCM_DEV_CONNECTION=scm:git@github.com:arturogutierrez/Badges.git
 POM_LICENCE_NAME=The Apache Software License, Version 2.0
 POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
-POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=arturogutierrez
 POM_DEVELOPER_NAME=Arturo Gutiérrez Díaz-Guerra
+POM_DEVELOPER_EMAIL=arturo.gutierrez@gmail.com


### PR DESCRIPTION
Reasons: 
- Old plugin don't have updates for 4 years
- Better javadocs generation
- Better pom file generation
- Smaller gradle.properties
- You can easy migrate from Maven Central to JCenter by adding to your code `IS_JCENTER = true` only and register at https://bintray.com/bintray/jcenter